### PR TITLE
Update setup check command to use twine

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -84,14 +84,13 @@ commands = detox -e setup,safety,style,docs,spell,link
 
 [testenv:setup]
 description = Check that the package will be correctly installed and correctly rendered on PyPI.
-skip_install = true
 deps =
-	docutils
 	check-manifest
 	readme-renderer
-	pygments
+	twine
 commands =
-	python setup.py check --strict --metadata --restructuredtext
+	python setup.py clean --all sdist bdist_wheel
+	twine check dist/*
 	check-manifest {toxinidir}
 
 [testenv:safety]
@@ -160,4 +159,3 @@ commands =
 	coverage report
 	coverage xml --ignore-errors
 	python-codacy-coverage []
-


### PR DESCRIPTION
I'm gonna split the previous PR in small ones.

Here is the first, to update the setup tox job to use `twine check` instead of `python setup.py check`.

Following PRs:
- https://github.com/Genida/django-appsettings/pull/41
- https://github.com/Genida/django-appsettings/pull/42
- https://github.com/Genida/django-appsettings/pull/43
- https://github.com/Genida/django-appsettings/pull/44

These PRs should be merged in that same order.

Compared to #39, this set of PR does not modify MANIFEST.in, and does not modify the code with `black` (we will do this later).

@ziima you can take a look if you want :slightly_smiling_face: 

I'm gonna merge this one already!