### PR TITLE
Refactor tox envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,13 @@ branches:
 cache: pip
 jobs:
   include:
-  - {stage: check, python: '3.5', env: TOX_ENV=setup}
-  - {stage: check, python: '3.5', env: TOX_ENV=safety}
-  - {stage: check, python: '3.5', env: TOX_ENV=style}
-  - {stage: check, python: '3.5', env: TOX_ENV=docs}
-  - {stage: check, python: '3.5', env: TOX_ENV=spell}
-  - {stage: check, python: '3.5', env: TOX_ENV=link}
+  - {stage: quality, python: '3.5', env: TOX_ENV=check-setup}
+  - {stage: quality, python: '3.5', env: TOX_ENV=check-bandit}
+  - {stage: quality, python: '3.5', env: TOX_ENV=check-safety}
+  - {stage: quality, python: '3.5', env: TOX_ENV=check-isort}
+  - {stage: quality, python: '3.5', env: TOX_ENV=check-docs-spell}
+  - {stage: quality, python: '3.5', env: TOX_ENV=check-docs-link}
+  - {stage: quality, python: '3.5', env: TOX_ENV=build-docs}
   - {stage: test, after_success: 'tox -e codacy', python: '2.7', env: TOX_ENV=py27-django18}
   - {stage: test, after_success: 'tox -e codacy', python: '2.7', env: TOX_ENV=py27-django19}
   - {stage: test, after_success: 'tox -e codacy', python: '2.7', env: TOX_ENV=py27-django110}
@@ -37,9 +38,8 @@ jobs:
   - {stage: test, after_success: 'tox -e codacy', python: pypy, env: TOX_ENV=pypy-django111}
   fast_finish: true
   allow_failures:
-  - {stage: check, python: '3.5', env: TOX_ENV=style}
-  - {stage: check, python: '3.5', env: TOX_ENV=spell}
-  - {stage: check, python: '3.5', env: TOX_ENV=link}
+  - {stage: quality, python: '3.5', env: TOX_ENV=check-docs-spell}
+  - {stage: quality, python: '3.5', env: TOX_ENV=check-docs-link}
   - {stage: test, python: 3.7-dev}
 addons:
   apt:

--- a/tox.ini
+++ b/tox.ini
@@ -84,14 +84,13 @@ commands = detox -e setup,safety,style,docs,spell,link
 
 [testenv:setup]
 description = Check that the package will be correctly installed and correctly rendered on PyPI.
-skip_install = true
 deps =
-	docutils
 	check-manifest
 	readme-renderer
-	pygments
+	twine
 commands =
-	python setup.py check --strict --metadata --restructuredtext
+	python setup.py clean --all sdist bdist_wheel
+	twine check dist/*
 	check-manifest {toxinidir}
 
 [testenv:safety]
@@ -160,4 +159,3 @@ commands =
 	coverage report
 	coverage xml --ignore-errors
 	python-codacy-coverage []
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,15 @@
 [tox]
 envlist =
-	clean,setup,safety,style,spell,link,docs,
+	clean,
+	check-setup,
+	check-bandit,
+	check-safety,
+	check-isort,
+	check-black,
+	check-flake8,
+	check-docs-spell,
+	check-docs-link,
+	build-docs,
 	py27-django18,
 	py27-django19,
 	py27-django110,
@@ -49,7 +58,12 @@ skip_install = true
 commands = tox -e py27-django18,py27-django19,py27-django110,py27-django111,py34-django18,py34-django19,py34-django110,py34-django111,py35-django18,py35-django19,py35-django110,py35-django111,py36-django18,py36-django19,py36-django110,py36-django111,py37-dev-django18,py37-dev-django19,py37-dev-django110,py37-dev-django111,pypy-django18,pypy-django19,pypy-django110,pypy-django111,
 	tox -e report
 
-[testenv:dtest]
+[testenv:check]
+description = Run all the check environments.
+skip_install = true
+commands = tox -e check-setup,check-bandit,check-safety,check-isort,check-black,check-flake8,check-docs-spell,check-docs-link
+
+[testenv:parallel-test]
 description = Run all the Python/Django test environments in parallel.
 skip_install = true
 deps = detox
@@ -57,32 +71,27 @@ commands =
 	detox -e py27-django18,py27-django19,py27-django110,py27-django111,py34-django18,py34-django19,py34-django110,py34-django111,py35-django18,py35-django19,py35-django110,py35-django111,py36-django18,py36-django19,py36-django110,py36-django111,py37-dev-django18,py37-dev-django19,py37-dev-django110,py37-dev-django111,pypy-django18,pypy-django19,pypy-django110,pypy-django111,
 	tox -e report
 
-[testenv:detox]
+[testenv:parallel-check]
+description = Run all the check environments in parallel.
+skip_install = true
+deps = detox
+commands = detox -e check-setup,check-bandit,check-safety,check-isort,check-black,check-flake8,check-docs-spell,check-docs-link
+
+[testenv:parallel-all]
 description = Run all the environments in parallel.
 skip_install = true
 deps = detox
 commands =
-	detox -e clean,setup,safety,style,spell,link,docs,py27-django18,py27-django19,py27-django110,py27-django111,py34-django18,py34-django19,py34-django110,py34-django111,py35-django18,py35-django19,py35-django110,py35-django111,py36-django18,py36-django19,py36-django110,py36-django111,py37-dev-django18,py37-dev-django19,py37-dev-django110,py37-dev-django111,pypy-django18,pypy-django19,pypy-django110,pypy-django111,
+	detox -e clean,build-docs,check-setup,check-bandit,check-safety,check-isort,check-black,check-flake8,check-docs-spell,check-docs-link,py27-django18,py27-django19,py27-django110,py27-django111,py34-django18,py34-django19,py34-django110,py34-django111,py35-django18,py35-django19,py35-django110,py35-django111,py36-django18,py36-django19,py36-django110,py36-django111,py37-dev-django18,py37-dev-django19,py37-dev-django110,py37-dev-django111,pypy-django18,pypy-django19,pypy-django110,pypy-django111,
 	tox -e report
 
-[testenv:docs]
+[testenv:build-docs]
 description = Build the documentation locally.
 skip_install = true
 deps = -r{toxinidir}/docs/requirements.txt
-commands = sphinx-build {posargs:-E} -b html docs dist/docs
+commands = sphinx-build {posargs:-E} -b html docs build/docs
 
-[testenv:check]
-description = Run all the check environments.
-skip_install = true
-commands = tox -e setup,safety,style,docs,spell,link
-
-[testenv:dcheck]
-description = Run all the check environments in parallel.
-skip_install = true
-deps = detox
-commands = detox -e setup,safety,style,docs,spell,link
-
-[testenv:setup]
+[testenv:check-setup]
 description = Check that the package will be correctly installed and correctly rendered on PyPI.
 deps =
 	check-manifest
@@ -93,27 +102,30 @@ commands =
 	twine check dist/*
 	check-manifest {toxinidir}
 
-[testenv:safety]
-description = Check that the requirements versions do not have security vulnerabilities.
+[testenv:check-bandit]
+description = Run bandit tool on the code.
 skip_install = true
 deps =
 	bandit
+commands =
+	bandit -r {toxinidir}/src/appsettings
+
+[testenv:check-safety]
+description = Check that the requirements versions do not have security vulnerabilities.
+skip_install = true
+deps =
 	safety
 commands =
 	safety check -r {toxinidir}/requirements/base.txt
-	bandit -r {toxinidir}/src/appsettings
 
-[testenv:style]
-description = Check the code style.
+[testenv:check-isort]
+description = Check the imports order.
 deps =
 	isort
-	prospector[with_everything]
-  django
 commands =
-	isort --diff --recursive src/appsettings tests setup.py
-	prospector {toxinidir}
+	isort --check-only --diff --recursive src/appsettings tests setup.py
 
-[testenv:spell]
+[testenv:check-docs-spell]
 description = Check the spelling in the documentation.
 skip_install = true
 setenv = SPELLCHECK=1
@@ -122,40 +134,52 @@ deps =
 	sphinxcontrib-spelling
 	pyenchant
 commands =
-	- sphinx-build {posargs:-E} -Q -b html docs dist/docs
-	sphinx-build -b spelling -w /dev/null docs dist/docs
+	- sphinx-build {posargs:-E} -Q -b html docs build/docs
+	sphinx-build -b spelling -w /dev/null docs build/docs
 
-[testenv:link]
+[testenv:check-docs-link]
 description = Check that the links written in documentation are valid.
 skip_install = true
 deps = -r{toxinidir}/docs/requirements.txt
 commands =
-	- sphinx-build {posargs:-E} -Q -b html docs dist/docs
-	sphinx-build -b linkcheck -w /dev/null docs dist/docs
+	- sphinx-build {posargs:-E} -Q -b html docs build/docs
+	sphinx-build -b linkcheck -w /dev/null docs build/docs
+
+[testenv:run-isort]
+description = Check the imports order.
+deps =
+	isort
+commands =
+	isort --apply --recursive src/appsettings tests setup.py
+
+[testenv:run-bumpversion]
+description = Increase the version number. Argument is 'patch', 'minor' or 'major'.
+deps =
+	bumpversion
+commands =
+	bumpversion {posargs}
 
 [testenv:report]
 description = Create coverage report.
-deps = coverage
 skip_install = true
+deps = coverage
 commands =
-	coverage combine --append
 	coverage report
 	coverage html
 
 [testenv:clean]
 description = Delete coverage report.
-commands = coverage erase
 skip_install = true
 deps = coverage
+commands = coverage erase
 
 [testenv:codacy]
 description = Upload coverage report to codacy.
+skip_install = true
 deps =
 	codacy-coverage
 	coverage
-skip_install = true
 commands =
-	coverage combine --append
 	coverage report
 	coverage xml --ignore-errors
 	python-codacy-coverage []


### PR DESCRIPTION
This PR renames the tox envs and adds a few, like `run-isort` and `run-bumpversion`.

Following PRs:
- https://github.com/Genida/django-appsettings/pull/42
- https://github.com/Genida/django-appsettings/pull/43
- https://github.com/Genida/django-appsettings/pull/44