### PR TITLE
Add callable path setting

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -58,6 +58,12 @@ API reference
 .. autoclass:: appsettings.ObjectSetting
     :members:
 
+``appsettings.CallablePathSetting`` setting
+-------------------------------------------
+
+.. autoclass:: appsettings.CallablePathSetting
+    :members:
+
 ``appsettings.NestedSetting`` setting
 -------------------------------------
 

--- a/src/appsettings/__init__.py
+++ b/src/appsettings/__init__.py
@@ -9,6 +9,7 @@ from django.core.signals import setting_changed
 from .settings import (
     BooleanSetting,
     BooleanTypeChecker,
+    CallablePathSetting,
     DictSetting,
     DictTypeChecker,
     FloatSetting,
@@ -38,6 +39,7 @@ from .validators import DictKeysTypeValidator, DictValuesTypeValidator, TypeVali
 __all__ = (
     "BooleanSetting",
     "BooleanTypeChecker",
+    "CallablePathSetting",
     "DictKeysTypeValidator",
     "DictSetting",
     "DictTypeChecker",

--- a/src/appsettings/settings.py
+++ b/src/appsettings/settings.py
@@ -1120,6 +1120,26 @@ class ObjectSetting(Setting):
         return current_object
 
 
+# Callable path settings ------------------------------------------------------
+class CallablePathSetting(ObjectSetting):
+    """
+    Callable path setting.
+
+    This setting value should be string containing a dotted path to a callable.
+    """
+
+    def validate(self, value):
+        """
+        Check whether the value is path to a callable.
+
+        We disregard the raw value and use transformed value instead.
+        """
+        super(CallablePathSetting, self).validate(value)
+        transformed_value = self.value
+        if not callable(transformed_value):
+            raise ValidationError("Value %(value)s is not a callable.", params={"value": transformed_value})
+
+
 # Nested settings -------------------------------------------------------------
 class NestedSetting(DictSetting):
     """Nested setting."""

--- a/tests/test_appsettings.py
+++ b/tests/test_appsettings.py
@@ -160,6 +160,8 @@ class TypeCheckerTestCase(SimpleTestCase):
 
 
 class SettingTestCase(SimpleTestCase):
+    NOT_A_CALLABLE = {}
+
     @staticmethod
     def _imported_object2():
         return "nothing"
@@ -388,6 +390,20 @@ class SettingTestCase(SimpleTestCase):
             assert setting.value is None
         with override_settings(OBJECT=None):
             assert setting.value is None
+
+    def test_callable_path_setting(self):
+        setting = appsettings.CallablePathSetting(name="callable_path")
+        setting.check()
+        assert setting.value is None
+        with override_settings(CALLABLE_PATH="tests.test_appsettings.imported_object"):
+            setting.check()
+            assert setting.value is imported_object
+        with override_settings(CALLABLE_PATH="tests.test_appsettings.SettingTestCase.NOT_A_CALLABLE"):
+            with pytest.raises(ValueError):
+                setting.check()
+        with override_settings(CALLABLE_PATH=None):
+            with pytest.raises(ValueError):
+                setting.check()
 
     def test_nested_setting(self):
         setting = appsettings.NestedSetting(settings=dict())


### PR DESCRIPTION
I considered writing a custom validator first, but I'd seem that I have to pass in the transform method. Otherwise I'm not able to access the transformed value in the validator. So, I overrode the `validate` method instead.

If you have a better idea how to implement this, I'm all ears.

Closes #49.