### PR TITLE
Fix tranform_default in NestedListSetting

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,6 @@
 -r base.txt
 
-pytest==3.4.1
+pytest==3.10.1
 pytest-travis-fold==1.3.0
 pytest-cov==2.5.1
 

--- a/src/appsettings/settings.py
+++ b/src/appsettings/settings.py
@@ -1305,3 +1305,7 @@ class NestedListSetting(IterableSetting):
                     errors.extend(error.messages)
             if errors:
                 raise ValidationError(errors)
+
+    def transform(self, value):
+        """Transform each item in the list."""
+        return tuple(self.inner_setting.transform(item) for item in value)

--- a/tests/test_appsettings.py
+++ b/tests/test_appsettings.py
@@ -445,9 +445,14 @@ class SettingTestCase(SimpleTestCase):
             with pytest.raises(ValueError):
                 setting.check()
 
-        setting = appsettings.NestedListSetting(name="setting", default=[], inner_setting=appsettings.ObjectSetting())
+        setting = appsettings.NestedListSetting(
+            name="setting",
+            default=["tests.test_appsettings.imported_object"],
+            transform_default=True,
+            inner_setting=appsettings.ObjectSetting()
+        )
         setting.check()
-        assert setting.value == []
+        assert setting.value == (imported_object,)
         with override_settings(
             SETTING=[
                 "tests.test_appsettings.imported_object",


### PR DESCRIPTION
I found an error in the implementation of `NestedListSetting`. Default value is not transformed in case that `transform_default` is set to `True`. I've created this pull request to fix the issue.

I also had to update the version of `pytest` in order for tests to pass. Unfortunatelly, there are still some pypy tests failing, but they are also failing on master (something about creating the virtualenv).