### PR TITLE
Fix NestedDictSettings requirement

### DIFF
--- a/src/appsettings/settings.py
+++ b/src/appsettings/settings.py
@@ -1206,13 +1206,20 @@ class NestedDictSetting(DictSetting):
         """
         super(NestedDictSetting, self).check()
         errors = []
-        for subsetting in self.settings.values():
-            try:
-                subsetting.check()
-            except ValidationError as error:
-                errors.extend(error.messages)
-        if errors:
-            raise ValidationError(errors)
+        try:
+            raw_value = self.raw_value
+        except AttributeError:
+            # If not required and not passed
+            pass
+        else:
+            if raw_value is not None:
+                for subsetting in self.settings.values():
+                    try:
+                        subsetting.check()
+                    except ValidationError as error:
+                        errors.extend(error.messages)
+                if errors:
+                    raise ValidationError(errors)
 
 
 class NestedSetting(NestedDictSetting):


### PR DESCRIPTION
Hello,

in the documentation of django-app-settings in the [Usage section](https://django-appsettings.readthedocs.io/en/latest/usage.html#nested-dict-settings) there is the first bullet saying:

> Empty configuration would be valid, because api setting is not required. In this case, api default value would be used, which is empty dictionary.

Actually, it does not work this way. I tried to come up with a fix which seems to be working.

Hope you find it well fixed and well tested. I tried to write tests to all possible scenarios, although some of them may have been tested before I guess.

Best regards,
Daniel